### PR TITLE
replaces the `cmd` entrypoint with pebble

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,6 +7,20 @@ license: Apache-2.0
 platforms:
   amd64:
 
+services:
+  nms:
+    override: replace
+    command: yarn run start:prod
+    environment:
+      PORT: 8080
+      HOST: 0.0.0.0
+      MYSQL_DIALECT: postgres
+      MYSQL_PASS: password
+      MYSQL_USER: username
+      MYSQL_DB: magma
+      MYSQL_PORT: 5432
+      MYSQL_HOST: postgres_container
+
 parts:
 
   magma-nms-magmalte:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,11 +7,6 @@ license: Apache-2.0
 platforms:
   amd64:
 
-services:
-  nms:
-    override: replace
-    command: /bin/yarn run start:prod
-
 parts:
 
   magma-nms-magmalte:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,7 +7,10 @@ license: Apache-2.0
 platforms:
   amd64:
 
-cmd: ["/bin/yarn", "run", "start:prod"]
+services:
+  nms:
+    override: replace
+    command: /bin/yarn run start:prod
 
 parts:
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,13 +4,16 @@
 
 """Integration tests for the nms-magmalte rock."""
 
+import logging
+import time
 import unittest
 from pathlib import Path
-from time import sleep
 
 import docker  # type: ignore[import]
 import requests
 import yaml
+
+logger = logging.getLogger(__name__)
 
 MAGMALTE_DOCKER_URL = "http://localhost"
 MAGMALTE_DOCKER_PORT = 8081
@@ -58,18 +61,8 @@ class TestNmsMagmalteRock(unittest.TestCase):
             f"ghcr.io/canonical/{image_name}:{version}",
             detach=True,
             ports={"8080/tcp": 8081},
+            command="start nms",
             name="app_container",
-            environment={
-                "PORT": "8080",
-                "HOST": "0.0.0.0",
-                "MYSQL_DIALECT": "postgres",
-                "MYSQL_PASS": POSTGRES_PASSWORD,
-                "MYSQL_USER": POSTGRES_USER,
-                "MYSQL_DB": POSTGRES_DB,
-                "MYSQL_PORT": "5432",
-                "MYSQL_HOST": "postgres_container",
-            },
-            command="/bin/yarn run start:prod",
         )
         self.network.connect(magmalte_container)
 
@@ -78,13 +71,15 @@ class TestNmsMagmalteRock(unittest.TestCase):
     ):
         """Test to validate that the container is running correctly."""
         url = f"{MAGMALTE_DOCKER_URL}:{MAGMALTE_DOCKER_PORT}{MAGMALTE_LOGIN_PAGE}"  # noqa: E501
-        for _ in range(30):
+        initial_time = time.time()
+        timeout = 30
+        while time.time() - initial_time < timeout:
             try:
                 response = requests.get(url)
-                if response.status_code == 200:
-                    break
-            except requests.exceptions.RequestException:
+                assert response.status_code == 200
+                return
+            except requests.exceptions.ConnectionError:
+                logger.info(f"Connection error when reaching {url}, will retry")
                 pass
-            sleep(1)
-        else:
-            assert False, "Failed to get a 200 response within 10 seconds."
+            time.sleep(1)
+        raise TimeoutError(f"Failed to get a 200 response within {timeout} seconds.")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -69,6 +69,7 @@ class TestNmsMagmalteRock(unittest.TestCase):
                 "MYSQL_PORT": "5432",
                 "MYSQL_HOST": "postgres_container",
             },
+            command="/bin/yarn run start:prod",
         )
         self.network.connect(magmalte_container)
 


### PR DESCRIPTION
### Overview

[Pebble is the new official entrypoint in rocks](https://discourse.canonical.com/t/the-rocks-gazette-2023-7/1762). This PR replaces the `cmd` entrypoint with pebble.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
